### PR TITLE
feat(bio): Use labels instead of badges

### DIFF
--- a/src/app/components/bio/bio.component.html
+++ b/src/app/components/bio/bio.component.html
@@ -17,11 +17,11 @@
             <app-bio-content></app-bio-content>
           </p>
           <h5>Interests</h5>
-          <span class="badge badge-1">DevOps</span>
-          <span class="badge badge-2">Cloud computing</span>
-          <span class="badge badge-3">Software development</span>
-          <span class="badge badge-4">Agile project management</span>
-          <span class="badge badge-5">Continuous delivery</span>
+          <span class="label clickable">Software development</span>
+          <span class="label label-purple clickable">Cloud computing</span>
+          <span class="label label-blue clickable">Continuous delivery</span>
+          <span class="label label-light-blue clickable">DevOps</span>
+          <span class="label label-orange clickable">Agile project management</span>
         </div>
       </div>
       <div class="card-footer">

--- a/src/app/components/bio/bio.component.spec.ts
+++ b/src/app/components/bio/bio.component.spec.ts
@@ -1,5 +1,6 @@
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 
 import { BioComponent } from './bio.component';
 
@@ -28,5 +29,10 @@ describe('BioComponent', () => {
   it('shoud include bio-content component', () => {
     const bioContent = fixture.debugElement.nativeElement.querySelector('app-bio-content');
     expect(bioContent).not.toBeNull();
+  });
+
+  it('shoud have clickable labels', () => {
+    const labels = fixture.debugElement.queryAll(By.css('.label.clickable'));
+    expect(labels.length).toEqual(5);
   });
 });


### PR DESCRIPTION
**Changes**

For the "Interests" section, use the class `label` instead of `badge`